### PR TITLE
Fix: trim url

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -24,7 +24,7 @@ export const useFetch = (url) => {
 
 	useEffect(() => {
 		let cancelRequest = false;
-		if (!url) return;
+		if (!url || !url.trim()) return;
 
 		const fetchData = async () => {
 			dispatch({ type: 'FETCHING' });


### PR DESCRIPTION
Trim user supplied `url` for potential empty spaces. Fixes #16 